### PR TITLE
Update to Rack v2 API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-# Must follow the format in the Naming section of https://vcvrack.com/manual/PluginDevelopmentTutorial.html
-
-# Must follow the format in the Versioning section of https://vcvrack.com/manual/PluginDevelopmentTutorial.html
+# If RACK_DIR is not defined when calling the Makefile, default to two directories above
+RACK_DIR ?= ../..
 
 # FLAGS will be passed to both the C and C++ compiler
 FLAGS +=
@@ -8,22 +7,17 @@ CFLAGS +=
 CXXFLAGS +=
 
 # Careful about linking to shared libraries, since you can't assume much about the user's environment and library search path.
-# Static libraries are fine.
+# Static libraries are fine, but they should be added to this plugin's build system.
 LDFLAGS +=
 
-# Add .cpp and .c files to the build
+# Add .cpp files to the build
 SOURCES += $(wildcard src/*.cpp)
 
 # Add files to the ZIP package when running `make dist`
-# The compiled plugin is automatically added.
-DISTRIBUTABLES += $(wildcard LICENSE*) res 
+# The compiled plugin and "plugin.json" are automatically added.
+DISTRIBUTABLES += res
+DISTRIBUTABLES += $(wildcard LICENSE*)
+DISTRIBUTABLES += $(wildcard presets)
 
-# If RACK_DIR is not defined when calling the Makefile, default to two levels above
-RACK_DIR ?= ../..
-
-# Include the VCV Rack plugin Makefile framework
+# Include the Rack plugin Makefile framework
 include $(RACK_DIR)/plugin.mk
-
-# Make resources
-
-RESOURCES += $(subst src/res/,res/,$(wildcard src/res/*.svg))

--- a/plugin.json
+++ b/plugin.json
@@ -9,7 +9,7 @@
 	"pluginUrl": "https://github.com/The-Great-Assyr/Chiptuner",
 	"sourceUrl": "https://github.com/The-Great-Assyr/Chiptuner",
 	"manualUrl": "https://github.com/The-Great-Assyr/Chiptuner/blob/master/README.md",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"modules": [
 		{
 			"slug":"Blank1HP",

--- a/src/Blanks.cpp
+++ b/src/Blanks.cpp
@@ -30,19 +30,6 @@ struct BlankBaseWidget : ModuleWidget {
 		delete bmp;
 		loadBitmap();
 	}
-	json_t *toJson() override {
-		json_t *rootJ = ModuleWidget::toJson();
-		json_object_set_new(rootJ, "style", json_real(selected));
-		return rootJ;
-	}
-	void fromJson(json_t *rootJ) override {
-		ModuleWidget::fromJson(rootJ);
-		int sel = selected;
-		json_t *styleJ = json_object_get(rootJ, "style");
-		if (styleJ)
-			sel = json_number_value(styleJ);
-		setBitmap(sel);
-	}	
 	
 };
 


### PR DESCRIPTION
Update to Rack v2 API - Repair/migration - VCVRack/library#591

- Removed JSON Methods from `ModuleWidget` subclass,
these were deprecated and removed. If you need to use them, use
`Engine::fromJson` or `RackWidget::fromJson`

- It looks like maybe since your plugin doesn't involve any processing from the engine (just artwork), then you may not need these methods at all.

- The `release()` method from `MFTexture` is currently causing VCV Rack to crash right before the program is closed due to unallocated memory issues. Will try to address this in the next commit.